### PR TITLE
Correct ordinal info for 100643

### DIFF
--- a/variable-info/data-coding-ordinal-info.txt
+++ b/variable-info/data-coding-ordinal-info.txt
@@ -172,7 +172,7 @@ dataCode,ordinal,ordering,reassignments,default_value,default_related_field
 100640,0,,,,
 100641,-1,,,,
 100642,-1,,,,
-100643,1,,,,
+100643,0,,,,
 100644,0,,,,
 100645,0,,,,
 100646,0,,,,


### PR DESCRIPTION
'ordinal' column of 100643 should be 0 (not ordinal) in file data-coding-ordinal-info.txt
Because data for FI1 : numeric addition test(4935) is non-ordinal. http://biobank.ctsu.ox.ac.uk/crystal/field.cgi?id=4935

ACE touchscreen question "Add the following numbers together: 1 2 3 4 5 - is the answer?". Part 1 of Fluid Intelligence test.
Asked to choose from 13, 14, 15, 16 or 17.
